### PR TITLE
동일한 유저의 특강 중복 신청에 대해 1번만 처리되도록 개선

### DIFF
--- a/src/main/java/io/project/lectureregister/global/common/exception/ErrorCode.java
+++ b/src/main/java/io/project/lectureregister/global/common/exception/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
     EXCEED_MAX_LECTURE_CAPACITY(NOT_FOUND, "특강 신청 수용 최대 인원을 초과하였습니다."),
 
     /* 409 CONFLICT : Resource의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
-    APPLY_LECTURE_DUPLICATE(CONFLICT, "이미 특강을 신청한 유저입니다.");
+    LECTURE_REGISTER_DUPLICATE(CONFLICT, "이미 특강을 신청한 유저입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/io/project/lectureregister/lecture/domain/entity/LectureRegistration.java
+++ b/src/main/java/io/project/lectureregister/lecture/domain/entity/LectureRegistration.java
@@ -9,7 +9,15 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "LECTURE_REGISTRATION")
+@Table(
+    name = "LECTURE_REGISTRATION",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "UQ_USER_LEC",
+            columnNames = {"LECTURE_ID", "USER_ID"}
+        )
+    }
+)
 @NoArgsConstructor
 @Getter
 public class LectureRegistration {

--- a/src/main/java/io/project/lectureregister/lecture/domain/repository/ILectureRegistrationRepository.java
+++ b/src/main/java/io/project/lectureregister/lecture/domain/repository/ILectureRegistrationRepository.java
@@ -5,11 +5,12 @@ import io.project.lectureregister.lecture.domain.entity.LectureRegistration;
 import io.project.lectureregister.user.domain.entity.User;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ILectureRegistrationRepository {
     LectureRegistration save(LectureRegistration lectureRegistration);
 
-    List<LectureRegistration> findByLecture(Lecture lecture);
+    Optional<LectureRegistration> findByLectureAndUser(Lecture lecture, User user);
 
     List<LectureRegistration> findByUser(User user);
 }

--- a/src/main/java/io/project/lectureregister/lecture/domain/service/LectureRegistrationService.java
+++ b/src/main/java/io/project/lectureregister/lecture/domain/service/LectureRegistrationService.java
@@ -21,7 +21,11 @@ public class LectureRegistrationService {
         if (lecture.isMaxCapacity()) {
             throw new CustomException(ErrorCode.EXCEED_MAX_LECTURE_CAPACITY);
         }
-        
+//        lectureRegistrationRepository.findByLectureAndUser(lecture, user)
+//                .ifPresent(r -> {
+//                    throw new CustomException(ErrorCode.LECTURE_REGISTER_DUPLICATE);
+//                });
+
         lecture.increaseCapacity();
 
         return lectureRegistrationRepository.save(LectureRegistration.create(lecture, user));

--- a/src/main/java/io/project/lectureregister/lecture/infrastructure/repository/LectureRegistrationJpaRepository.java
+++ b/src/main/java/io/project/lectureregister/lecture/infrastructure/repository/LectureRegistrationJpaRepository.java
@@ -2,10 +2,11 @@ package io.project.lectureregister.lecture.infrastructure.repository;
 
 import io.project.lectureregister.lecture.domain.entity.Lecture;
 import io.project.lectureregister.lecture.domain.entity.LectureRegistration;
+import io.project.lectureregister.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import java.util.Optional;
 
 public interface LectureRegistrationJpaRepository extends JpaRepository<LectureRegistration, Long> {
-    List<LectureRegistration> findByLecture(Lecture lecture);
+    Optional<LectureRegistration> findByLectureAndUser(Lecture lecture, User user);
 }

--- a/src/main/java/io/project/lectureregister/lecture/infrastructure/repository/LectureRegistrationRepository.java
+++ b/src/main/java/io/project/lectureregister/lecture/infrastructure/repository/LectureRegistrationRepository.java
@@ -5,9 +5,11 @@ import io.project.lectureregister.lecture.domain.entity.LectureRegistration;
 import io.project.lectureregister.lecture.domain.repository.ILectureRegistrationRepository;
 import io.project.lectureregister.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,8 +24,8 @@ public class LectureRegistrationRepository implements ILectureRegistrationReposi
     }
 
     @Override
-    public List<LectureRegistration> findByLecture(Lecture lecture) {
-        return lectureRegistrationJpaRepository.findByLecture(lecture);
+    public Optional<LectureRegistration> findByLectureAndUser(Lecture lecture, User user) {
+        return lectureRegistrationJpaRepository.findByLectureAndUser(lecture, user);
     }
 
     @Override

--- a/src/test/java/io/project/lectureregister/lecture/application/LectureFacadeConcurrencyTest.java
+++ b/src/test/java/io/project/lectureregister/lecture/application/LectureFacadeConcurrencyTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -93,5 +94,53 @@ public class LectureFacadeConcurrencyTest {
         // then
         assertThat(successCount.get()).isEqualTo(maxCapacity);
         assertThat(failCount.get()).isEqualTo(10);
+    }
+
+    @DisplayName("동일한 유저로 동시에 특강을 5번 신청했을 때, 1번만 성공하고 나머지는 실패해야 한다.")
+    @Test
+    void registerConcurrentlyWithSameUser() throws Exception {
+        // given
+        User user = User.createUser("PARK01", "test01@gmail.com", LocalDateTime.now());
+        userJpaRepository.save(user);
+
+        int maxCapacity = 30;
+        Lecture lecture = Lecture.createLecture("플러스 특강", 1, maxCapacity,
+                LocalDateTime.of(2025, Month.JANUARY, 7, 15, 0),
+                LocalDateTime.of(2025, Month.JANUARY, 7, 18, 0));
+        lectureJpaRepository.save(lecture);
+
+        int threadCount = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(4);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    lectureFacade.register(
+                            LectureRegisterCommand.builder()
+                                    .userId(user.getUserId())
+                                    .lectureId(lecture.getLectureId())
+                                    .build()
+                    );
+                    successCount.incrementAndGet();
+                } catch (DataIntegrityViolationException ex) {
+                    failCount.incrementAndGet();
+//                } catch (CustomException e) {
+//                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(4);
     }
 }


### PR DESCRIPTION
### **커밋 링크**
- 특강 중복 신청 이슈 처리 : [973e121](https://github.com/park0691/lecture-register/commit/979f7f6640316d47eeee10e65c86e7c055387d7b)

---
### **리뷰 포인트(질문)**
- 중복 신청 처리를 방지하기 위해 고려한 두 가지 방법이 있습니다.
  1.  서비스 단에서 사용자, 강좌 아이디(USER_ID, LECTURE_ID)로 조회되는 특강 신청 정보가 존재하는 경우 예외 처리
  2.  DB 테이블 UNIQUE 제약 조건 추가
  - 첫 번째 방법으로 시도했으나, 중복 신청 문제가 해결되지 않아 두 번째 방법으로 해결했습니다.
  - 첫 번째 방법이 동작 안 되는 이유가 궁금합니다.
    - `LectureRegistrationService.java` 24 - 27라인, `LectureFacadeConcurrencyTest` 132 - 133라인 주석 처리한 부분입니다.
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->

### Problem
<!--개선이 필요한 점-->

### Try
<!-- 새롭게 시도할 점 -->
